### PR TITLE
Add priority to middleware to control exec order

### DIFF
--- a/examples/efficient-broadcast/main.go
+++ b/examples/efficient-broadcast/main.go
@@ -88,7 +88,7 @@ func main() {
 			return
 		}
 
-		nn.MustApplyMiddleware(routing.RemoteMessageRouted(func(remoteMessage *node.RemoteMessage, localNode *node.LocalNode, remoteNodes []*node.RemoteNode) (*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode, bool) {
+		nn.MustApplyMiddleware(routing.RemoteMessageRouted{func(remoteMessage *node.RemoteMessage, localNode *node.LocalNode, remoteNodes []*node.RemoteNode) (*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode, bool) {
 			if remoteMessage.Msg.MessageType == protobuf.BYTES {
 				msgBody := &protobuf.Bytes{}
 				err = proto.Unmarshal(remoteMessage.Msg.Message, msgBody)
@@ -108,7 +108,7 @@ func main() {
 				msgCountLock.Unlock()
 			}
 			return remoteMessage, localNode, remoteNodes, true
-		}))
+		}, 0})
 
 		nnets = append(nnets, nn)
 	}

--- a/examples/message-benchmark/main.go
+++ b/examples/message-benchmark/main.go
@@ -86,12 +86,12 @@ func main() {
 			return
 		}
 
-		nn.MustApplyMiddleware(node.BytesReceived(func(msg, msgID, srcID []byte, remoteNode *node.RemoteNode) ([]byte, bool) {
+		nn.MustApplyMiddleware(node.BytesReceived{func(msg, msgID, srcID []byte, remoteNode *node.RemoteNode) ([]byte, bool) {
 			msgCountLock.Lock()
 			msgCount++
 			msgCountLock.Unlock()
 			return msg, true
-		}))
+		}, 0})
 
 		nnets = append(nnets, nn)
 	}

--- a/examples/message/main.go
+++ b/examples/message/main.go
@@ -66,7 +66,7 @@ func main() {
 			return
 		}
 
-		nn.MustApplyMiddleware(node.BytesReceived(func(msg, msgID, srcID []byte, remoteNode *node.RemoteNode) ([]byte, bool) {
+		nn.MustApplyMiddleware(node.BytesReceived{func(msg, msgID, srcID []byte, remoteNode *node.RemoteNode) ([]byte, bool) {
 			log.Infof("Receive message \"%s\" from %x by %x", string(msg), srcID, remoteNode.Id)
 
 			_, err = nn.SendBytesRelayReply(msgID, []byte("Well received!"), srcID)
@@ -75,18 +75,18 @@ func main() {
 			}
 
 			return msg, true
-		}))
+		}, 0})
 
 		nnets = append(nnets, nn)
 	}
 
-	nnets[0].MustApplyMiddleware(chord.FingerTableAdded(func(remoteNode *node.RemoteNode, fingerIndex, nodeIndex int) bool {
+	nnets[0].MustApplyMiddleware(chord.FingerTableAdded{func(remoteNode *node.RemoteNode, fingerIndex, nodeIndex int) bool {
 		err = nnets[0].SendBytesDirectAsync([]byte("Hello my finger!"), remoteNode)
 		if err != nil {
 			log.Error(err)
 		}
 		return true
-	}))
+	}, 0})
 
 	for i := 0; i < len(nnets); i++ {
 		time.Sleep(112358 * time.Microsecond)

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -58,60 +58,70 @@ func main() {
 		return
 	}
 
-	nn.MustApplyMiddleware(overlay.NetworkWillStart(func(network overlay.Network) bool {
+	nn.MustApplyMiddleware(overlay.NetworkWillStart{func(network overlay.Network) bool {
 		log.Infof("Network will start")
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(overlay.NetworkStarted(func(network overlay.Network) bool {
+	nn.MustApplyMiddleware(overlay.NetworkStarted{func(network overlay.Network) bool {
 		log.Infof("Network started")
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(overlay.NetworkWillStop(func(network overlay.Network) bool {
+	nn.MustApplyMiddleware(overlay.NetworkWillStop{func(network overlay.Network) bool {
 		log.Infof("Network will stop")
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(overlay.NetworkStopped(func(network overlay.Network) bool {
+	nn.MustApplyMiddleware(overlay.NetworkStopped{func(network overlay.Network) bool {
 		log.Infof("Network stopped")
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(node.RemoteNodeConnected(func(remoteNode *node.RemoteNode) bool {
+	nn.MustApplyMiddleware(node.RemoteNodeConnected{func(remoteNode *node.RemoteNode) bool {
 		log.Infof("Remote node connected: %v", remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(node.RemoteNodeReady(func(remoteNode *node.RemoteNode) bool {
-		log.Infof("Remote node ready: %v", remoteNode)
+	nn.MustApplyMiddleware(node.RemoteNodeReady{func(remoteNode *node.RemoteNode) bool {
+		log.Infof("Remote node ready (normal priority): %v", remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(node.RemoteNodeDisconnected(func(remoteNode *node.RemoteNode) bool {
+	nn.MustApplyMiddleware(node.RemoteNodeReady{func(remoteNode *node.RemoteNode) bool {
+		log.Infof("Remote node ready (higher priority): %v", remoteNode)
+		return true
+	}, 1})
+
+	nn.MustApplyMiddleware(node.RemoteNodeReady{func(remoteNode *node.RemoteNode) bool {
+		log.Infof("Remote node ready (lower priority): %v", remoteNode)
+		return true
+	}, -1})
+
+	nn.MustApplyMiddleware(node.RemoteNodeDisconnected{func(remoteNode *node.RemoteNode) bool {
 		log.Infof("Remote node disconnected: %v", remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(chord.NeighborAdded(func(remoteNode *node.RemoteNode, index int) bool {
+	nn.MustApplyMiddleware(chord.NeighborAdded{func(remoteNode *node.RemoteNode, index int) bool {
 		log.Infof("New neighbor %d: %v", index, remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(chord.SuccessorAdded(func(remoteNode *node.RemoteNode, index int) bool {
+	nn.MustApplyMiddleware(chord.SuccessorAdded{func(remoteNode *node.RemoteNode, index int) bool {
 		log.Infof("New successor %d: %v", index, remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(chord.PredecessorAdded(func(remoteNode *node.RemoteNode, index int) bool {
+	nn.MustApplyMiddleware(chord.PredecessorAdded{func(remoteNode *node.RemoteNode, index int) bool {
 		log.Infof("New predecessor %d: %v", index, remoteNode)
 		return true
-	}))
+	}, 0})
 
-	nn.MustApplyMiddleware(chord.FingerTableAdded(func(remoteNode *node.RemoteNode, fingerIndex, nodeIndex int) bool {
+	nn.MustApplyMiddleware(chord.FingerTableAdded{func(remoteNode *node.RemoteNode, fingerIndex, nodeIndex int) bool {
 		log.Infof("New finger table %d-%d: %v", fingerIndex, nodeIndex, remoteNode)
 		return true
-	}))
+	}, 0})
 
 	err = nn.Start(true)
 	if err != nil {
@@ -130,19 +140,19 @@ func main() {
 			return
 		}
 
-		nn.MustApplyMiddleware(node.RemoteNodeConnected(func(remoteNode *node.RemoteNode) bool {
+		nn.MustApplyMiddleware(node.RemoteNodeConnected{func(remoteNode *node.RemoteNode) bool {
 			if rand.Float64() < 0.23333 {
 				remoteNode.Stop(errors.New("YOU ARE UNLUCKY"))
 				// stop propagate to the next middleware
 				return false
 			}
 			return true
-		}))
+		}, 0})
 
-		nn.MustApplyMiddleware(node.RemoteNodeConnected(func(remoteNode *node.RemoteNode) bool {
+		nn.MustApplyMiddleware(node.RemoteNodeConnected{func(remoteNode *node.RemoteNode) bool {
 			log.Infof("Only lucky remote node can get here :)")
 			return true
-		}))
+		}, 0})
 
 		err = nn.Start(false)
 		if err != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -8,18 +8,18 @@ import (
 // ApplyMiddleware add a middleware to node, network, router, etc. If multiple
 // middleware of the same type are applied, they will be called in the order of
 // being added.
-func (nn *NNet) ApplyMiddleware(f interface{}) error {
+func (nn *NNet) ApplyMiddleware(mw interface{}) error {
 	applied := false
 	errs := util.NewErrors()
 
-	err := nn.GetLocalNode().ApplyMiddleware(f)
+	err := nn.GetLocalNode().ApplyMiddleware(mw)
 	if err == nil {
 		applied = true
 	} else {
 		errs = append(errs, err)
 	}
 
-	err = nn.Network.ApplyMiddleware(f)
+	err = nn.Network.ApplyMiddleware(mw)
 	if err == nil {
 		applied = true
 	} else {
@@ -27,7 +27,7 @@ func (nn *NNet) ApplyMiddleware(f interface{}) error {
 	}
 
 	for _, router := range nn.GetRouters() {
-		err = router.ApplyMiddleware(f)
+		err = router.ApplyMiddleware(mw)
 		if err == nil {
 			applied = true
 		} else {
@@ -45,8 +45,8 @@ func (nn *NNet) ApplyMiddleware(f interface{}) error {
 // MustApplyMiddleware is the same as ApplyMiddleware, but will panic if an
 // error occurs. This is a convenient shortcut if ApplyMiddleware is not
 // expected to fail.
-func (nn *NNet) MustApplyMiddleware(f interface{}) {
-	err := nn.ApplyMiddleware(f)
+func (nn *NNet) MustApplyMiddleware(mw interface{}) {
+	err := nn.ApplyMiddleware(mw)
 	if err != nil {
 		log.Error(err)
 		panic(err)

--- a/middleware/priority.go
+++ b/middleware/priority.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"reflect"
+	"sort"
+)
+
+func getPriority(v reflect.Value) int32 {
+	return int32(v.FieldByName("Priority").Int())
+}
+
+// Sort sorts an array/slice of middleware
+func Sort(middlewares interface{}) {
+	sort.SliceStable(middlewares, func(i int, j int) bool {
+		s := reflect.ValueOf(middlewares)
+		if s.Kind() != reflect.Slice {
+			panic("Sort input is not a slice")
+		}
+		return getPriority(s.Index(i)) > getPriority(s.Index(j))
+	})
+}

--- a/node/localnode.go
+++ b/node/localnode.go
@@ -85,8 +85,8 @@ func NewLocalNode(id []byte, conf *config.Config) (*LocalNode, error) {
 // Start starts the runtime loop of the local node
 func (ln *LocalNode) Start() error {
 	ln.StartOnce.Do(func() {
-		for _, f := range ln.middlewareStore.localNodeWillStart {
-			if !f(ln) {
+		for _, mw := range ln.middlewareStore.localNodeWillStart {
+			if !mw.Func(ln) {
 				break
 			}
 		}
@@ -97,8 +97,8 @@ func (ln *LocalNode) Start() error {
 
 		go ln.listen()
 
-		for _, f := range ln.middlewareStore.localNodeStarted {
-			if !f(ln) {
+		for _, mw := range ln.middlewareStore.localNodeStarted {
+			if !mw.Func(ln) {
 				break
 			}
 		}
@@ -110,8 +110,8 @@ func (ln *LocalNode) Start() error {
 // Stop stops the local node
 func (ln *LocalNode) Stop(err error) {
 	ln.StopOnce.Do(func() {
-		for _, f := range ln.middlewareStore.localNodeWillStop {
-			if !f(ln) {
+		for _, mw := range ln.middlewareStore.localNodeWillStop {
+			if !mw.Func(ln) {
 				break
 			}
 		}
@@ -138,8 +138,8 @@ func (ln *LocalNode) Stop(err error) {
 			ln.listener.Close()
 		}
 
-		for _, f := range ln.middlewareStore.localNodeStopped {
-			if !f(ln) {
+		for _, mw := range ln.middlewareStore.localNodeStopped {
+			if !mw.Func(ln) {
 				break
 			}
 		}
@@ -296,8 +296,8 @@ func (ln *LocalNode) StartRemoteNode(conn net.Conn, isOutbound bool) (*RemoteNod
 		return nil, err
 	}
 
-	for _, f := range ln.middlewareStore.remoteNodeConnected {
-		if !f(remoteNode) {
+	for _, mw := range ln.middlewareStore.remoteNodeConnected {
+		if !mw.Func(remoteNode) {
 			break
 		}
 	}

--- a/node/message.go
+++ b/node/message.go
@@ -196,8 +196,8 @@ func (ln *LocalNode) handleRemoteMessage(remoteMsg *RemoteMessage) error {
 
 		data := msgBody.Data
 		var shouldCallNextMiddleware bool
-		for _, f := range ln.middlewareStore.bytesReceived {
-			data, shouldCallNextMiddleware = f(data, remoteMsg.Msg.MessageId, remoteMsg.Msg.SrcId, remoteMsg.RemoteNode)
+		for _, mw := range ln.middlewareStore.bytesReceived {
+			data, shouldCallNextMiddleware = mw.Func(data, remoteMsg.Msg.MessageId, remoteMsg.Msg.SrcId, remoteMsg.RemoteNode)
 			if !shouldCallNextMiddleware {
 				break
 			}

--- a/node/remotenode.go
+++ b/node/remotenode.go
@@ -156,8 +156,8 @@ func (rn *RemoteNode) Start() error {
 
 			rn.SetReady(true)
 
-			for _, f := range rn.LocalNode.middlewareStore.remoteNodeReady {
-				if !f(rn) {
+			for _, mw := range rn.LocalNode.middlewareStore.remoteNodeReady {
+				if !mw.Func(rn) {
 					break
 				}
 			}
@@ -189,8 +189,8 @@ func (rn *RemoteNode) Stop(err error) {
 				rn.conn.Close()
 			}
 
-			for _, f := range rn.LocalNode.middlewareStore.remoteNodeDisconnected {
-				if !f(rn) {
+			for _, mw := range rn.LocalNode.middlewareStore.remoteNodeDisconnected {
+				if !mw.Func(rn) {
 					break
 				}
 			}

--- a/overlay/chord/neighbor.go
+++ b/overlay/chord/neighbor.go
@@ -42,8 +42,8 @@ func (c *Chord) addSuccessor(remoteNode *node.RemoteNode) error {
 		if added {
 			index := c.successors.GetIndex(remoteNode.Id)
 			if index >= 0 {
-				for _, f := range c.middlewareStore.successorAdded {
-					if !f(remoteNode, index) {
+				for _, mw := range c.middlewareStore.successorAdded {
+					if !mw.Func(remoteNode, index) {
 						break
 					}
 				}
@@ -51,8 +51,8 @@ func (c *Chord) addSuccessor(remoteNode *node.RemoteNode) error {
 		}
 
 		if replaced != nil {
-			for _, f := range c.middlewareStore.successorRemoved {
-				if !f(replaced) {
+			for _, mw := range c.middlewareStore.successorRemoved {
+				if !mw.Func(replaced) {
 					break
 				}
 			}
@@ -75,8 +75,8 @@ func (c *Chord) addPredecessor(remoteNode *node.RemoteNode) error {
 		if added {
 			index := c.predecessors.GetIndex(remoteNode.Id)
 			if index >= 0 {
-				for _, f := range c.middlewareStore.predecessorAdded {
-					if !f(remoteNode, index) {
+				for _, mw := range c.middlewareStore.predecessorAdded {
+					if !mw.Func(remoteNode, index) {
 						break
 					}
 				}
@@ -84,8 +84,8 @@ func (c *Chord) addPredecessor(remoteNode *node.RemoteNode) error {
 		}
 
 		if replaced != nil {
-			for _, f := range c.middlewareStore.predecessorRemoved {
-				if !f(replaced) {
+			for _, mw := range c.middlewareStore.predecessorRemoved {
+				if !mw.Func(replaced) {
 					break
 				}
 			}
@@ -110,8 +110,8 @@ func (c *Chord) addFingerTable(remoteNode *node.RemoteNode, index int) error {
 		if added {
 			i := finger.GetIndex(remoteNode.Id)
 			if i >= 0 {
-				for _, f := range c.middlewareStore.fingerTableAdded {
-					if !f(remoteNode, index, i) {
+				for _, mw := range c.middlewareStore.fingerTableAdded {
+					if !mw.Func(remoteNode, index, i) {
 						break
 					}
 				}
@@ -119,8 +119,8 @@ func (c *Chord) addFingerTable(remoteNode *node.RemoteNode, index int) error {
 		}
 
 		if replaced != nil {
-			for _, f := range c.middlewareStore.fingerTableRemoved {
-				if !f(replaced, index) {
+			for _, mw := range c.middlewareStore.fingerTableRemoved {
+				if !mw.Func(replaced, index) {
 					break
 				}
 			}
@@ -147,8 +147,8 @@ func (c *Chord) addNeighbor(remoteNode *node.RemoteNode) error {
 		if added {
 			index := c.neighbors.GetIndex(remoteNode.Id)
 			if index >= 0 {
-				for _, f := range c.middlewareStore.neighborAdded {
-					if !f(remoteNode, index) {
+				for _, mw := range c.middlewareStore.neighborAdded {
+					if !mw.Func(remoteNode, index) {
 						break
 					}
 				}
@@ -156,8 +156,8 @@ func (c *Chord) addNeighbor(remoteNode *node.RemoteNode) error {
 		}
 
 		if replaced != nil {
-			for _, f := range c.middlewareStore.neighborRemoved {
-				if !f(replaced) {
+			for _, mw := range c.middlewareStore.neighborRemoved {
+				if !mw.Func(replaced) {
 					break
 				}
 			}
@@ -204,8 +204,8 @@ func (c *Chord) addRemoteNode(remoteNode *node.RemoteNode) error {
 func (c *Chord) removeNeighbor(remoteNode *node.RemoteNode) error {
 	removed := c.successors.Remove(remoteNode)
 	if removed {
-		for _, f := range c.middlewareStore.successorRemoved {
-			if !f(remoteNode) {
+		for _, mw := range c.middlewareStore.successorRemoved {
+			if !mw.Func(remoteNode) {
 				break
 			}
 		}
@@ -222,8 +222,8 @@ func (c *Chord) removeNeighbor(remoteNode *node.RemoteNode) error {
 
 	removed = c.predecessors.Remove(remoteNode)
 	if removed {
-		for _, f := range c.middlewareStore.predecessorRemoved {
-			if !f(remoteNode) {
+		for _, mw := range c.middlewareStore.predecessorRemoved {
+			if !mw.Func(remoteNode) {
 				break
 			}
 		}
@@ -242,8 +242,8 @@ func (c *Chord) removeNeighbor(remoteNode *node.RemoteNode) error {
 	for i, finger := range c.fingerTable {
 		removed = finger.Remove(remoteNode)
 		if removed {
-			for _, f := range c.middlewareStore.fingerTableRemoved {
-				if !f(remoteNode, i) {
+			for _, mw := range c.middlewareStore.fingerTableRemoved {
+				if !mw.Func(remoteNode, i) {
 					break
 				}
 			}
@@ -261,8 +261,8 @@ func (c *Chord) removeNeighbor(remoteNode *node.RemoteNode) error {
 
 	removed = c.neighbors.Remove(remoteNode)
 	if removed {
-		for _, f := range c.middlewareStore.neighborRemoved {
-			if !f(remoteNode) {
+		for _, mw := range c.middlewareStore.neighborRemoved {
+			if !mw.Func(remoteNode) {
 				break
 			}
 		}

--- a/overlay/middleware.go
+++ b/overlay/middleware.go
@@ -2,16 +2,28 @@ package overlay
 
 // NetworkWillStart is called right before network starts listening and handling
 // messages. It can be used to do additional network setup like NAT traversal.
-type NetworkWillStart func(Network) bool
+type NetworkWillStart struct {
+	Func     func(Network) bool
+	Priority int32
+}
 
 // NetworkStarted is called right after network starts listening and handling
 // messages.
-type NetworkStarted func(Network) bool
+type NetworkStarted struct {
+	Func     func(Network) bool
+	Priority int32
+}
 
 // NetworkWillStop is called right before network stops listening and handling
 // messages.
-type NetworkWillStop func(Network) bool
+type NetworkWillStop struct {
+	Func     func(Network) bool
+	Priority int32
+}
 
 // NetworkStopped is called right after network stops listening and handling
 // messages. It can be used to do some clean up, etc.
-type NetworkStopped func(Network) bool
+type NetworkStopped struct {
+	Func     func(Network) bool
+	Priority int32
+}

--- a/overlay/routing/middleware.go
+++ b/overlay/routing/middleware.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"errors"
 
+	"github.com/nknorg/nnet/middleware"
 	"github.com/nknorg/nnet/node"
 )
 
@@ -11,7 +12,10 @@ import (
 // will each trigger this middleware once. This can be used to process, modify
 // or discard message. Returns the remote message to be used (or nil to discard
 // the message) and if we should proceed to the next middleware.
-type RemoteMessageArrived func(*node.RemoteMessage) (*node.RemoteMessage, bool)
+type RemoteMessageArrived struct {
+	Func     func(*node.RemoteMessage) (*node.RemoteMessage, bool)
+	Priority int32
+}
 
 // RemoteMessageRouted is called when the router has computed the node to route
 // (could be the local node, remote nodes, or both), and before the message is
@@ -20,14 +24,20 @@ type RemoteMessageArrived func(*node.RemoteMessage) (*node.RemoteMessage, bool)
 // discard message, or change routes. Returns the remote message to be used (or
 // nil to discard the message), local node and remote nodes where the message
 // should be routed to, and if we should proceed to the next middleware.
-type RemoteMessageRouted func(*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode) (*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode, bool)
+type RemoteMessageRouted struct {
+	Func     func(*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode) (*node.RemoteMessage, *node.LocalNode, []*node.RemoteNode, bool)
+	Priority int32
+}
 
 // RemoteMessageReceived is called when a new remote message is received, routed
 // to local node, and prepare to be handled by local node. Message with the same
 // message id will only trigger this middleware once. This can be used to
 // process, modify or discard message. Returns the remote message to be used (or
 // nil to discard the message) and if we should proceed to the next middleware.
-type RemoteMessageReceived func(*node.RemoteMessage) (*node.RemoteMessage, bool)
+type RemoteMessageReceived struct {
+	Func     func(*node.RemoteMessage) (*node.RemoteMessage, bool)
+	Priority int32
+}
 
 // middlewareStore stores the functions that will be called when certain events
 // are triggered or in some pipeline
@@ -47,23 +57,26 @@ func newMiddlewareStore() *middlewareStore {
 }
 
 // ApplyMiddleware add a middleware to the store
-func (store *middlewareStore) ApplyMiddleware(f interface{}) error {
-	switch f := f.(type) {
+func (store *middlewareStore) ApplyMiddleware(mw interface{}) error {
+	switch mw := mw.(type) {
 	case RemoteMessageArrived:
-		if f == nil {
-			return errors.New("middleware is nil")
+		if mw.Func == nil {
+			return errors.New("middleware function is nil")
 		}
-		store.remoteMessageArrived = append(store.remoteMessageArrived, f)
+		store.remoteMessageArrived = append(store.remoteMessageArrived, mw)
+		middleware.Sort(store.remoteMessageArrived)
 	case RemoteMessageRouted:
-		if f == nil {
-			return errors.New("middleware is nil")
+		if mw.Func == nil {
+			return errors.New("middleware function is nil")
 		}
-		store.remoteMessageRouted = append(store.remoteMessageRouted, f)
+		store.remoteMessageRouted = append(store.remoteMessageRouted, mw)
+		middleware.Sort(store.remoteMessageRouted)
 	case RemoteMessageReceived:
-		if f == nil {
-			return errors.New("middleware is nil")
+		if mw.Func == nil {
+			return errors.New("middleware function is nil")
 		}
-		store.remoteMessageReceived = append(store.remoteMessageReceived, f)
+		store.remoteMessageReceived = append(store.remoteMessageReceived, mw)
+		middleware.Sort(store.remoteMessageReceived)
 	default:
 		return errors.New("unknown middleware type")
 	}

--- a/overlay/routing/routing.go
+++ b/overlay/routing/routing.go
@@ -74,8 +74,8 @@ func (r *Routing) SendMessage(router Router, remoteMsg *node.RemoteMessage, hasR
 		return nil, false, err
 	}
 
-	for _, f := range r.middlewareStore.remoteMessageRouted {
-		remoteMsg, localNode, remoteNodes, shouldCallNextMiddleware = f(remoteMsg, localNode, remoteNodes)
+	for _, mw := range r.middlewareStore.remoteMessageRouted {
+		remoteMsg, localNode, remoteNodes, shouldCallNextMiddleware = mw.Func(remoteMsg, localNode, remoteNodes)
 		if remoteMsg == nil || !shouldCallNextMiddleware {
 			break
 		}
@@ -127,8 +127,8 @@ func (r *Routing) SendMessage(router Router, remoteMsg *node.RemoteMessage, hasR
 func (r *Routing) sendMessageToLocalNode(remoteMsg *node.RemoteMessage, localNode *node.LocalNode) error {
 	var shouldCallNextMiddleware bool
 
-	for _, f := range r.middlewareStore.remoteMessageReceived {
-		remoteMsg, shouldCallNextMiddleware = f(remoteMsg)
+	for _, mw := range r.middlewareStore.remoteMessageReceived {
+		remoteMsg, shouldCallNextMiddleware = mw.Func(remoteMsg)
 		if remoteMsg == nil || !shouldCallNextMiddleware {
 			break
 		}
@@ -173,8 +173,8 @@ func (r *Routing) handleMsg(router Router) {
 
 		remoteMsg = <-r.rxMsgChan
 
-		for _, f := range r.middlewareStore.remoteMessageArrived {
-			remoteMsg, shouldCallNextMiddleware = f(remoteMsg)
+		for _, mw := range r.middlewareStore.remoteMessageArrived {
+			remoteMsg, shouldCallNextMiddleware = mw.Func(remoteMsg)
 			if remoteMsg == nil || !shouldCallNextMiddleware {
 				break
 			}


### PR DESCRIPTION
Previously middleware are called in the order of being added, so the middleware added by nnet internally will always be called first.

Now with priority being implemented, one can make a middleware being called first before overlay network, e.g. to validate nodes and disconnect.

This is a breaking change, but luckily only tiny changes are required to adapt to the new api.