### PR TITLE
Change GetNode to ExchangeNode for 2-way node exchange

### DIFF
--- a/node/localnode.go
+++ b/node/localnode.go
@@ -304,7 +304,7 @@ func (ln *LocalNode) Connect(n *protobuf.Node) (*RemoteNode, bool, error) {
 }
 
 // StartRemoteNode creates and starts a remote node using conn. If n is not
-// nil, its id and address will be used to validate GetNode response.
+// nil, its id and address will be used to validate ExchangeNode info.
 func (ln *LocalNode) StartRemoteNode(conn net.Conn, isOutbound bool, n *protobuf.Node) (*RemoteNode, error) {
 	remoteNode, err := NewRemoteNode(ln, conn, isOutbound, n)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/nknorg/nnet/common"
 	"github.com/nknorg/nnet/protobuf"
@@ -9,6 +10,7 @@ import (
 
 // Node is a remote or local node
 type Node struct {
+	sync.RWMutex
 	*protobuf.Node
 	common.LifeCycle
 }

--- a/overlay/chord/chord.go
+++ b/overlay/chord/chord.go
@@ -210,6 +210,9 @@ func (c *Chord) Start(isCreate bool) error {
 					}
 				}
 
+				// This is needed if len(succs) == 0
+				c.SetReady(true)
+
 				c.stabilize()
 			})
 			return true

--- a/protobuf/message.pb.go
+++ b/protobuf/message.pb.go
@@ -54,16 +54,16 @@ var RoutingType_value = map[string]int32{
 }
 
 func (RoutingType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{0}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{0}
 }
 
 type MessageType int32
 
 const (
 	// Node message
-	PING     MessageType = 0
-	GET_NODE MessageType = 1
-	STOP     MessageType = 2
+	PING          MessageType = 0
+	EXCHANGE_NODE MessageType = 1
+	STOP          MessageType = 2
 	// Chord message
 	GET_SUCC_AND_PRED  MessageType = 3
 	FIND_SUCC_AND_PRED MessageType = 4
@@ -73,7 +73,7 @@ const (
 
 var MessageType_name = map[int32]string{
 	0: "PING",
-	1: "GET_NODE",
+	1: "EXCHANGE_NODE",
 	2: "STOP",
 	3: "GET_SUCC_AND_PRED",
 	4: "FIND_SUCC_AND_PRED",
@@ -81,7 +81,7 @@ var MessageType_name = map[int32]string{
 }
 var MessageType_value = map[string]int32{
 	"PING":               0,
-	"GET_NODE":           1,
+	"EXCHANGE_NODE":      1,
 	"STOP":               2,
 	"GET_SUCC_AND_PRED":  3,
 	"FIND_SUCC_AND_PRED": 4,
@@ -89,7 +89,7 @@ var MessageType_value = map[string]int32{
 }
 
 func (MessageType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{1}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{1}
 }
 
 type Message struct {
@@ -105,7 +105,7 @@ type Message struct {
 func (m *Message) Reset()      { *m = Message{} }
 func (*Message) ProtoMessage() {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{0}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{0}
 }
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -189,7 +189,7 @@ type Ping struct {
 func (m *Ping) Reset()      { *m = Ping{} }
 func (*Ping) ProtoMessage() {}
 func (*Ping) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{1}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{1}
 }
 func (m *Ping) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -224,7 +224,7 @@ type PingReply struct {
 func (m *PingReply) Reset()      { *m = PingReply{} }
 func (*PingReply) ProtoMessage() {}
 func (*PingReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{2}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{2}
 }
 func (m *PingReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -253,56 +253,21 @@ func (m *PingReply) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PingReply proto.InternalMessageInfo
 
-type GetNode struct {
-}
-
-func (m *GetNode) Reset()      { *m = GetNode{} }
-func (*GetNode) ProtoMessage() {}
-func (*GetNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{3}
-}
-func (m *GetNode) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *GetNode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_GetNode.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (dst *GetNode) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetNode.Merge(dst, src)
-}
-func (m *GetNode) XXX_Size() int {
-	return m.Size()
-}
-func (m *GetNode) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetNode.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetNode proto.InternalMessageInfo
-
-type GetNodeReply struct {
+type ExchangeNode struct {
 	Node *Node `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
 }
 
-func (m *GetNodeReply) Reset()      { *m = GetNodeReply{} }
-func (*GetNodeReply) ProtoMessage() {}
-func (*GetNodeReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{4}
+func (m *ExchangeNode) Reset()      { *m = ExchangeNode{} }
+func (*ExchangeNode) ProtoMessage() {}
+func (*ExchangeNode) Descriptor() ([]byte, []int) {
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{3}
 }
-func (m *GetNodeReply) XXX_Unmarshal(b []byte) error {
+func (m *ExchangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *GetNodeReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ExchangeNode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_GetNodeReply.Marshal(b, m, deterministic)
+		return xxx_messageInfo_ExchangeNode.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalTo(b)
@@ -312,19 +277,62 @@ func (m *GetNodeReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *GetNodeReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetNodeReply.Merge(dst, src)
+func (dst *ExchangeNode) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExchangeNode.Merge(dst, src)
 }
-func (m *GetNodeReply) XXX_Size() int {
+func (m *ExchangeNode) XXX_Size() int {
 	return m.Size()
 }
-func (m *GetNodeReply) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetNodeReply.DiscardUnknown(m)
+func (m *ExchangeNode) XXX_DiscardUnknown() {
+	xxx_messageInfo_ExchangeNode.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetNodeReply proto.InternalMessageInfo
+var xxx_messageInfo_ExchangeNode proto.InternalMessageInfo
 
-func (m *GetNodeReply) GetNode() *Node {
+func (m *ExchangeNode) GetNode() *Node {
+	if m != nil {
+		return m.Node
+	}
+	return nil
+}
+
+type ExchangeNodeReply struct {
+	Node *Node `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+}
+
+func (m *ExchangeNodeReply) Reset()      { *m = ExchangeNodeReply{} }
+func (*ExchangeNodeReply) ProtoMessage() {}
+func (*ExchangeNodeReply) Descriptor() ([]byte, []int) {
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{4}
+}
+func (m *ExchangeNodeReply) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ExchangeNodeReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ExchangeNodeReply.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (dst *ExchangeNodeReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExchangeNodeReply.Merge(dst, src)
+}
+func (m *ExchangeNodeReply) XXX_Size() int {
+	return m.Size()
+}
+func (m *ExchangeNodeReply) XXX_DiscardUnknown() {
+	xxx_messageInfo_ExchangeNodeReply.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ExchangeNodeReply proto.InternalMessageInfo
+
+func (m *ExchangeNodeReply) GetNode() *Node {
 	if m != nil {
 		return m.Node
 	}
@@ -337,7 +345,7 @@ type Stop struct {
 func (m *Stop) Reset()      { *m = Stop{} }
 func (*Stop) ProtoMessage() {}
 func (*Stop) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{5}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{5}
 }
 func (m *Stop) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -374,7 +382,7 @@ type GetSuccAndPred struct {
 func (m *GetSuccAndPred) Reset()      { *m = GetSuccAndPred{} }
 func (*GetSuccAndPred) ProtoMessage() {}
 func (*GetSuccAndPred) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{6}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{6}
 }
 func (m *GetSuccAndPred) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -425,7 +433,7 @@ type GetSuccAndPredReply struct {
 func (m *GetSuccAndPredReply) Reset()      { *m = GetSuccAndPredReply{} }
 func (*GetSuccAndPredReply) ProtoMessage() {}
 func (*GetSuccAndPredReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{7}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{7}
 }
 func (m *GetSuccAndPredReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -477,7 +485,7 @@ type FindSuccAndPred struct {
 func (m *FindSuccAndPred) Reset()      { *m = FindSuccAndPred{} }
 func (*FindSuccAndPred) ProtoMessage() {}
 func (*FindSuccAndPred) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{8}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{8}
 }
 func (m *FindSuccAndPred) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -535,7 +543,7 @@ type FindSuccAndPredReply struct {
 func (m *FindSuccAndPredReply) Reset()      { *m = FindSuccAndPredReply{} }
 func (*FindSuccAndPredReply) ProtoMessage() {}
 func (*FindSuccAndPredReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{9}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{9}
 }
 func (m *FindSuccAndPredReply) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -585,7 +593,7 @@ type Bytes struct {
 func (m *Bytes) Reset()      { *m = Bytes{} }
 func (*Bytes) ProtoMessage() {}
 func (*Bytes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_b201eaadc96a9d44, []int{10}
+	return fileDescriptor_message_d56a4f06d2ed73d2, []int{10}
 }
 func (m *Bytes) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -625,8 +633,8 @@ func init() {
 	proto.RegisterType((*Message)(nil), "protobuf.Message")
 	proto.RegisterType((*Ping)(nil), "protobuf.Ping")
 	proto.RegisterType((*PingReply)(nil), "protobuf.PingReply")
-	proto.RegisterType((*GetNode)(nil), "protobuf.GetNode")
-	proto.RegisterType((*GetNodeReply)(nil), "protobuf.GetNodeReply")
+	proto.RegisterType((*ExchangeNode)(nil), "protobuf.ExchangeNode")
+	proto.RegisterType((*ExchangeNodeReply)(nil), "protobuf.ExchangeNodeReply")
 	proto.RegisterType((*Stop)(nil), "protobuf.Stop")
 	proto.RegisterType((*GetSuccAndPred)(nil), "protobuf.GetSuccAndPred")
 	proto.RegisterType((*GetSuccAndPredReply)(nil), "protobuf.GetSuccAndPredReply")
@@ -734,14 +742,14 @@ func (this *PingReply) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *GetNode) Equal(that interface{}) bool {
+func (this *ExchangeNode) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*GetNode)
+	that1, ok := that.(*ExchangeNode)
 	if !ok {
-		that2, ok := that.(GetNode)
+		that2, ok := that.(ExchangeNode)
 		if ok {
 			that1 = &that2
 		} else {
@@ -753,16 +761,19 @@ func (this *GetNode) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
+	if !this.Node.Equal(that1.Node) {
+		return false
+	}
 	return true
 }
-func (this *GetNodeReply) Equal(that interface{}) bool {
+func (this *ExchangeNodeReply) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*GetNodeReply)
+	that1, ok := that.(*ExchangeNodeReply)
 	if !ok {
-		that2, ok := that.(GetNodeReply)
+		that2, ok := that.(ExchangeNodeReply)
 		if ok {
 			that1 = &that2
 		} else {
@@ -989,21 +1000,24 @@ func (this *PingReply) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-func (this *GetNode) GoString() string {
-	if this == nil {
-		return "nil"
-	}
-	s := make([]string, 0, 4)
-	s = append(s, "&protobuf.GetNode{")
-	s = append(s, "}")
-	return strings.Join(s, "")
-}
-func (this *GetNodeReply) GoString() string {
+func (this *ExchangeNode) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 5)
-	s = append(s, "&protobuf.GetNodeReply{")
+	s = append(s, "&protobuf.ExchangeNode{")
+	if this.Node != nil {
+		s = append(s, "Node: "+fmt.Sprintf("%#v", this.Node)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *ExchangeNodeReply) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&protobuf.ExchangeNodeReply{")
 	if this.Node != nil {
 		s = append(s, "Node: "+fmt.Sprintf("%#v", this.Node)+",\n")
 	}
@@ -1184,7 +1198,7 @@ func (m *PingReply) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func (m *GetNode) Marshal() (dAtA []byte, err error) {
+func (m *ExchangeNode) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -1194,25 +1208,7 @@ func (m *GetNode) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *GetNode) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	return i, nil
-}
-
-func (m *GetNodeReply) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *GetNodeReply) MarshalTo(dAtA []byte) (int, error) {
+func (m *ExchangeNode) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -1226,6 +1222,34 @@ func (m *GetNodeReply) MarshalTo(dAtA []byte) (int, error) {
 			return 0, err
 		}
 		i += n1
+	}
+	return i, nil
+}
+
+func (m *ExchangeNodeReply) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ExchangeNodeReply) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Node != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintMessage(dAtA, i, uint64(m.Node.Size()))
+		n2, err := m.Node.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
 	}
 	return i, nil
 }
@@ -1475,15 +1499,18 @@ func NewPopulatedPingReply(r randyMessage, easy bool) *PingReply {
 	return this
 }
 
-func NewPopulatedGetNode(r randyMessage, easy bool) *GetNode {
-	this := &GetNode{}
+func NewPopulatedExchangeNode(r randyMessage, easy bool) *ExchangeNode {
+	this := &ExchangeNode{}
+	if r.Intn(10) != 0 {
+		this.Node = NewPopulatedNode(r, easy)
+	}
 	if !easy && r.Intn(10) != 0 {
 	}
 	return this
 }
 
-func NewPopulatedGetNodeReply(r randyMessage, easy bool) *GetNodeReply {
-	this := &GetNodeReply{}
+func NewPopulatedExchangeNodeReply(r randyMessage, easy bool) *ExchangeNodeReply {
+	this := &ExchangeNodeReply{}
 	if r.Intn(10) != 0 {
 		this.Node = NewPopulatedNode(r, easy)
 	}
@@ -1701,16 +1728,20 @@ func (m *PingReply) Size() (n int) {
 	return n
 }
 
-func (m *GetNode) Size() (n int) {
+func (m *ExchangeNode) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
+	if m.Node != nil {
+		l = m.Node.Size()
+		n += 1 + l + sovMessage(uint64(l))
+	}
 	return n
 }
 
-func (m *GetNodeReply) Size() (n int) {
+func (m *ExchangeNodeReply) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1868,20 +1899,21 @@ func (this *PingReply) String() string {
 	}, "")
 	return s
 }
-func (this *GetNode) String() string {
+func (this *ExchangeNode) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&GetNode{`,
+	s := strings.Join([]string{`&ExchangeNode{`,
+		`Node:` + strings.Replace(fmt.Sprintf("%v", this.Node), "Node", "Node", 1) + `,`,
 		`}`,
 	}, "")
 	return s
 }
-func (this *GetNodeReply) String() string {
+func (this *ExchangeNodeReply) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&GetNodeReply{`,
+	s := strings.Join([]string{`&ExchangeNodeReply{`,
 		`Node:` + strings.Replace(fmt.Sprintf("%v", this.Node), "Node", "Node", 1) + `,`,
 		`}`,
 	}, "")
@@ -2302,7 +2334,7 @@ func (m *PingReply) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *GetNode) Unmarshal(dAtA []byte) error {
+func (m *ExchangeNode) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2325,12 +2357,45 @@ func (m *GetNode) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: GetNode: wiretype end group for non-group")
+			return fmt.Errorf("proto: ExchangeNode: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: GetNode: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ExchangeNode: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Node", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Node == nil {
+				m.Node = &Node{}
+			}
+			if err := m.Node.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipMessage(dAtA[iNdEx:])
@@ -2352,7 +2417,7 @@ func (m *GetNode) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *GetNodeReply) Unmarshal(dAtA []byte) error {
+func (m *ExchangeNodeReply) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2375,10 +2440,10 @@ func (m *GetNodeReply) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: GetNodeReply: wiretype end group for non-group")
+			return fmt.Errorf("proto: ExchangeNodeReply: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: GetNodeReply: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ExchangeNodeReply: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -3102,47 +3167,48 @@ var (
 	ErrIntOverflowMessage   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("protobuf/message.proto", fileDescriptor_message_b201eaadc96a9d44) }
+func init() { proto.RegisterFile("protobuf/message.proto", fileDescriptor_message_d56a4f06d2ed73d2) }
 
-var fileDescriptor_message_b201eaadc96a9d44 = []byte{
-	// 617 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x53, 0x3d, 0x6f, 0xd3, 0x50,
-	0x14, 0xf5, 0x4b, 0x9c, 0xaf, 0x9b, 0x10, 0xcc, 0x2b, 0x2d, 0xa1, 0x88, 0xa7, 0xca, 0x53, 0x55,
-	0x89, 0x54, 0x0a, 0x0b, 0x03, 0x4b, 0x3e, 0xdc, 0x60, 0xa9, 0xa4, 0x91, 0xed, 0x0e, 0x9d, 0x4c,
-	0xeb, 0xf7, 0x08, 0x11, 0xc4, 0x2f, 0xf2, 0xc7, 0x10, 0x26, 0x26, 0x66, 0x7e, 0x06, 0x3f, 0x81,
-	0x9f, 0xc0, 0xd8, 0xb1, 0x23, 0x71, 0x17, 0xc6, 0x8e, 0x8c, 0xe8, 0x3d, 0xdb, 0x6d, 0x12, 0x95,
-	0x95, 0xc9, 0xf7, 0x9e, 0x73, 0xcf, 0xf1, 0x3d, 0x57, 0x36, 0xec, 0xcc, 0x03, 0x1e, 0xf1, 0x8b,
-	0xf8, 0xfd, 0xe1, 0x8c, 0x85, 0xe1, 0xf9, 0x84, 0xb5, 0x25, 0x80, 0xab, 0x39, 0xbe, 0xfb, 0x62,
-	0x32, 0x8d, 0x3e, 0xc4, 0x17, 0x6d, 0x8f, 0xcf, 0x0e, 0x27, 0x7c, 0xc2, 0x0f, 0x6f, 0x15, 0xa2,
-	0x93, 0x8d, 0xac, 0x52, 0xe1, 0xee, 0xd6, 0x2d, 0xed, 0x73, 0x9a, 0xb9, 0xe9, 0x5f, 0x0b, 0x50,
-	0x79, 0x9b, 0xfa, 0xe3, 0x57, 0xd0, 0x08, 0x78, 0x1c, 0x4d, 0xfd, 0x89, 0x1b, 0x2d, 0xe6, 0xac,
-	0x85, 0xf6, 0xd0, 0x7e, 0xb3, 0xb3, 0xdd, 0xce, 0x75, 0x6d, 0x2b, 0x65, 0x9d, 0xc5, 0x9c, 0x59,
-	0xf5, 0xe0, 0xae, 0x11, 0xca, 0x6c, 0xc9, 0x54, 0x59, 0xd8, 0x54, 0x66, 0xaf, 0x48, 0x95, 0xb3,
-	0xbb, 0x06, 0xb7, 0xa0, 0x92, 0xb5, 0xad, 0xe2, 0x1e, 0xda, 0x6f, 0x58, 0x79, 0x8b, 0x9f, 0x03,
-	0xe4, 0x9e, 0x53, 0xda, 0x52, 0x25, 0x59, 0xcb, 0x10, 0x93, 0x62, 0x02, 0xf5, 0x80, 0xcd, 0x3f,
-	0x2d, 0xdc, 0x88, 0x0b, 0xbe, 0x94, 0xf2, 0x12, 0x72, 0xb8, 0x49, 0xf1, 0x36, 0x94, 0xc3, 0xc0,
-	0x13, 0x54, 0x59, 0x52, 0xa5, 0x30, 0xf0, 0x4c, 0x8a, 0x9f, 0x40, 0x85, 0xb2, 0x30, 0x12, 0x78,
-	0x45, 0xe2, 0x65, 0xd1, 0x9a, 0x54, 0x2f, 0x83, 0x3a, 0x9e, 0xfa, 0x13, 0xbd, 0x0e, 0x35, 0xf1,
-	0xb4, 0x84, 0x91, 0x5e, 0x83, 0xca, 0x90, 0x45, 0x23, 0x4e, 0x99, 0xde, 0x81, 0x46, 0x56, 0x4a,
-	0x0a, 0xeb, 0xa0, 0x8a, 0x33, 0xca, 0x23, 0xd5, 0x3b, 0xcd, 0xbb, 0xa8, 0x72, 0x44, 0x72, 0xc2,
-	0xd3, 0x8e, 0xf8, 0x5c, 0x3f, 0x82, 0xe6, 0x90, 0x45, 0x76, 0xec, 0x79, 0x5d, 0x9f, 0x8e, 0x03,
-	0x46, 0xf1, 0x53, 0xa8, 0xfa, 0xf1, 0xcc, 0x0d, 0x63, 0xcf, 0x93, 0x0e, 0x0f, 0xac, 0x8a, 0x1f,
-	0xcf, 0xc4, 0x44, 0x4e, 0xcd, 0x03, 0x46, 0xe5, 0x1d, 0x53, 0x4a, 0xa8, 0xf4, 0x05, 0x6c, 0xad,
-	0xfb, 0xa4, 0xab, 0xb4, 0x01, 0x84, 0x11, 0x0b, 0x43, 0x1e, 0x84, 0x2d, 0xb4, 0x57, 0xbc, 0x67,
-	0xa1, 0x95, 0x09, 0xdc, 0x81, 0x86, 0x70, 0x67, 0xb9, 0xa2, 0x70, 0xaf, 0x62, 0x6d, 0x46, 0x3f,
-	0x83, 0x87, 0x47, 0x53, 0x9f, 0xae, 0x66, 0xd0, 0xa0, 0xf8, 0x91, 0x2d, 0xe4, 0xfa, 0x0d, 0x4b,
-	0x94, 0x6b, 0xa9, 0x0a, 0xff, 0x4e, 0x55, 0x5c, 0x4f, 0xf5, 0x19, 0x1e, 0x6f, 0x58, 0xff, 0xbf,
-	0x58, 0xcf, 0xa0, 0xd4, 0x5b, 0x44, 0x2c, 0xc4, 0x18, 0x54, 0x7a, 0x1e, 0x9d, 0x67, 0x69, 0x64,
-	0x7d, 0xf0, 0x0e, 0xea, 0x2b, 0x5f, 0x3c, 0x06, 0x28, 0x0f, 0x4c, 0xcb, 0xe8, 0x3b, 0x9a, 0x82,
-	0x6b, 0x50, 0xb2, 0x8c, 0xe3, 0xee, 0x99, 0x86, 0x30, 0x86, 0x66, 0xcf, 0x3a, 0xe9, 0x0e, 0xfa,
-	0x5d, 0xdb, 0x71, 0xc7, 0xa7, 0xf6, 0x1b, 0xad, 0xb0, 0x89, 0x1d, 0x1f, 0x6b, 0xc5, 0x75, 0xcc,
-	0xb1, 0x0c, 0x43, 0x53, 0x0f, 0xa6, 0x50, 0x5f, 0xf9, 0x33, 0x70, 0x15, 0xd4, 0xb1, 0x39, 0x1a,
-	0x6a, 0x0a, 0x6e, 0x40, 0x75, 0x68, 0x38, 0xee, 0xe8, 0x64, 0x60, 0x68, 0x48, 0xe0, 0xb6, 0x73,
-	0x32, 0xd6, 0x0a, 0x78, 0x1b, 0x1e, 0x09, 0xdc, 0x3e, 0xed, 0xf7, 0xdd, 0xee, 0x68, 0xe0, 0x8e,
-	0x2d, 0x63, 0xa0, 0x15, 0xf1, 0x0e, 0xe0, 0x23, 0x73, 0x34, 0xd8, 0xc0, 0x55, 0xb1, 0x66, 0xef,
-	0xcc, 0x31, 0x6c, 0xad, 0xd4, 0x7b, 0x7d, 0xb9, 0x24, 0xca, 0xd5, 0x92, 0x28, 0x37, 0x4b, 0x82,
-	0xfe, 0x2c, 0x09, 0xfa, 0x92, 0x10, 0xf4, 0x3d, 0x21, 0xe8, 0x47, 0x42, 0xd0, 0xcf, 0x84, 0xa0,
-	0xcb, 0x84, 0xa0, 0x5f, 0x09, 0x41, 0xbf, 0x13, 0xa2, 0xdc, 0x24, 0x04, 0x7d, 0xbb, 0x26, 0xca,
-	0xe5, 0x35, 0x51, 0xae, 0xae, 0x89, 0x72, 0x51, 0x96, 0x47, 0x7c, 0xf9, 0x37, 0x00, 0x00, 0xff,
-	0xff, 0xc6, 0x6c, 0x4c, 0x39, 0x95, 0x04, 0x00, 0x00,
+var fileDescriptor_message_d56a4f06d2ed73d2 = []byte{
+	// 636 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x53, 0x3f, 0x6f, 0xd3, 0x40,
+	0x1c, 0xf5, 0x25, 0x8e, 0xd3, 0xfe, 0x92, 0x06, 0xf7, 0x4a, 0x4b, 0x28, 0xe2, 0x54, 0x79, 0xaa,
+	0x2a, 0x91, 0x4a, 0x61, 0x80, 0x81, 0x25, 0x7f, 0xdc, 0xd4, 0x52, 0x49, 0x23, 0xdb, 0x95, 0xe8,
+	0x64, 0x52, 0xdf, 0xe1, 0x46, 0x10, 0x3b, 0xf2, 0x1f, 0x89, 0x30, 0x31, 0x31, 0xf3, 0x31, 0xf8,
+	0x08, 0x7c, 0x04, 0xc6, 0x8e, 0x1d, 0x89, 0xbb, 0x30, 0x76, 0x64, 0x44, 0x77, 0x4e, 0x9a, 0x3f,
+	0x2a, 0x12, 0x13, 0x93, 0xef, 0xbd, 0x77, 0xef, 0xf9, 0xf7, 0x7e, 0xd2, 0xc1, 0xce, 0x28, 0x0c,
+	0xe2, 0xe0, 0x22, 0x79, 0x77, 0x38, 0x64, 0x51, 0xd4, 0xf7, 0x58, 0x4d, 0x10, 0x78, 0x6d, 0xc6,
+	0xef, 0x3e, 0xf3, 0x06, 0xf1, 0x65, 0x72, 0x51, 0x73, 0x83, 0xe1, 0xa1, 0x17, 0x78, 0xc1, 0xe1,
+	0x9d, 0x83, 0x23, 0x01, 0xc4, 0x29, 0x33, 0xee, 0x6e, 0xdd, 0xc9, 0x7e, 0x40, 0xa7, 0x69, 0xda,
+	0x97, 0x1c, 0x14, 0x5f, 0x67, 0xf9, 0xf8, 0x25, 0x94, 0xc3, 0x20, 0x89, 0x07, 0xbe, 0xe7, 0xc4,
+	0xe3, 0x11, 0xab, 0xa2, 0x3d, 0xb4, 0x5f, 0xa9, 0x6f, 0xd7, 0x66, 0xbe, 0x9a, 0x99, 0xa9, 0xf6,
+	0x78, 0xc4, 0xcc, 0x52, 0x38, 0x07, 0xdc, 0x39, 0x1d, 0x32, 0x73, 0xe6, 0x56, 0x9d, 0xd3, 0x5f,
+	0x64, 0xce, 0xe1, 0x1c, 0xe0, 0x2a, 0x14, 0xa7, 0xb0, 0x9a, 0xdf, 0x43, 0xfb, 0x65, 0x73, 0x06,
+	0xf1, 0x53, 0x80, 0x59, 0xe6, 0x80, 0x56, 0x65, 0x21, 0xae, 0x4f, 0x19, 0x83, 0x62, 0x02, 0xa5,
+	0x90, 0x8d, 0x3e, 0x8c, 0x9d, 0x38, 0xe0, 0x7a, 0x21, 0xd3, 0x05, 0x65, 0x07, 0x06, 0xc5, 0xdb,
+	0xa0, 0x44, 0xa1, 0xcb, 0x25, 0x45, 0x48, 0x85, 0x28, 0x74, 0x0d, 0x8a, 0x1f, 0x41, 0x91, 0xb2,
+	0x28, 0xe6, 0x7c, 0x51, 0xf0, 0x0a, 0x87, 0x06, 0xd5, 0x14, 0x90, 0x7b, 0x03, 0xdf, 0xd3, 0x4a,
+	0xb0, 0xce, 0xbf, 0x26, 0x0f, 0xd2, 0xea, 0x50, 0xd6, 0x3f, 0xba, 0x97, 0x7d, 0xdf, 0x63, 0xdd,
+	0x80, 0x32, 0xac, 0x81, 0xcc, 0x77, 0x27, 0x36, 0x53, 0xaa, 0x57, 0xe6, 0xfd, 0xb8, 0x6a, 0x0a,
+	0x4d, 0x7b, 0x01, 0x9b, 0x8b, 0x1e, 0x11, 0xf4, 0x4f, 0x46, 0x05, 0x64, 0x2b, 0x0e, 0x46, 0xda,
+	0x11, 0x54, 0x3a, 0x2c, 0xb6, 0x12, 0xd7, 0x6d, 0xf8, 0xb4, 0x17, 0x32, 0x8a, 0x1f, 0xc3, 0x9a,
+	0x9f, 0x0c, 0x9d, 0x28, 0x71, 0x5d, 0x91, 0xb0, 0x61, 0x16, 0xfd, 0x64, 0xc8, 0x6f, 0xcc, 0xa4,
+	0x51, 0xc8, 0xa8, 0xd8, 0x7a, 0x26, 0x71, 0x97, 0x36, 0x86, 0xad, 0xe5, 0x9c, 0x6c, 0x94, 0x1a,
+	0x00, 0x0f, 0x62, 0x51, 0x14, 0x84, 0x51, 0x15, 0xed, 0xe5, 0xef, 0x19, 0x68, 0xe1, 0x06, 0xae,
+	0x43, 0x99, 0xa7, 0xb3, 0x99, 0x23, 0x77, 0xaf, 0x63, 0xe9, 0x8e, 0x76, 0x0e, 0x0f, 0x8e, 0x06,
+	0x3e, 0x5d, 0xec, 0xa0, 0x42, 0xfe, 0x3d, 0x1b, 0x8b, 0xf1, 0xcb, 0x26, 0x3f, 0x2e, 0xb5, 0xca,
+	0xfd, 0xbd, 0x55, 0x7e, 0xb9, 0xd5, 0x27, 0x78, 0xb8, 0x12, 0xfd, 0xff, 0x6a, 0x3d, 0x81, 0x42,
+	0x73, 0x1c, 0xb3, 0x08, 0x63, 0x90, 0x69, 0x3f, 0xee, 0x4f, 0xdb, 0x88, 0xf3, 0xc1, 0x5b, 0x28,
+	0x2d, 0xbc, 0x0f, 0x0c, 0xa0, 0xb4, 0x0d, 0x53, 0x6f, 0xd9, 0xaa, 0x84, 0xd7, 0xa1, 0x60, 0xea,
+	0x27, 0x8d, 0x73, 0x15, 0x61, 0x0c, 0x95, 0xa6, 0x79, 0xda, 0x68, 0xb7, 0x1a, 0x96, 0xed, 0xf4,
+	0xce, 0xac, 0x63, 0x35, 0xb7, 0xca, 0x9d, 0x9c, 0xa8, 0xf9, 0x65, 0xce, 0x36, 0x75, 0x5d, 0x95,
+	0x0f, 0x7c, 0x28, 0x2d, 0xbc, 0x23, 0xbc, 0x06, 0x72, 0xcf, 0xe8, 0x76, 0x54, 0x09, 0x6f, 0xc2,
+	0x86, 0xfe, 0xa6, 0x75, 0xdc, 0xe8, 0x76, 0x74, 0xa7, 0x7b, 0xda, 0xd6, 0x55, 0xc4, 0x45, 0xcb,
+	0x3e, 0xed, 0xa9, 0x39, 0xbc, 0x0d, 0x9b, 0x1d, 0xdd, 0x76, 0xac, 0xb3, 0x56, 0xcb, 0x69, 0x74,
+	0xdb, 0x4e, 0xcf, 0xd4, 0xdb, 0x6a, 0x1e, 0xef, 0x00, 0x3e, 0x32, 0xba, 0xed, 0x15, 0x5e, 0xe6,
+	0xb3, 0x36, 0xcf, 0x6d, 0xdd, 0x52, 0x0b, 0xcd, 0x57, 0x57, 0x13, 0x22, 0x5d, 0x4f, 0x88, 0x74,
+	0x3b, 0x21, 0xe8, 0xf7, 0x84, 0xa0, 0xcf, 0x29, 0x41, 0xdf, 0x52, 0x82, 0xbe, 0xa7, 0x04, 0xfd,
+	0x48, 0x09, 0xba, 0x4a, 0x09, 0xfa, 0x99, 0x12, 0xf4, 0x2b, 0x25, 0xd2, 0x6d, 0x4a, 0xd0, 0xd7,
+	0x1b, 0x22, 0x5d, 0xdd, 0x10, 0xe9, 0xfa, 0x86, 0x48, 0x17, 0x8a, 0xd8, 0xe4, 0xf3, 0x3f, 0x01,
+	0x00, 0x00, 0xff, 0xff, 0xdc, 0x72, 0x8b, 0xb9, 0xc8, 0x04, 0x00, 0x00,
 }

--- a/protobuf/message.proto
+++ b/protobuf/message.proto
@@ -28,7 +28,7 @@ enum RoutingType {
 enum MessageType {
   // Node message
   PING = 0;
-  GET_NODE = 1;
+  EXCHANGE_NODE = 1;
   STOP = 2;
 
   // Chord message
@@ -55,10 +55,11 @@ message Ping {
 message PingReply {
 }
 
-message GetNode {
+message ExchangeNode {
+  Node node = 1;
 }
 
-message GetNodeReply {
+message ExchangeNodeReply {
   Node node = 1;
 }
 

--- a/protobuf/messagepb_test.go
+++ b/protobuf/messagepb_test.go
@@ -187,15 +187,15 @@ func TestPingReplyMarshalTo(t *testing.T) {
 	}
 }
 
-func TestGetNodeProto(t *testing.T) {
+func TestExchangeNodeProto(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, false)
+	p := NewPopulatedExchangeNode(popr, false)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNode{}
+	msg := &ExchangeNode{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -218,10 +218,10 @@ func TestGetNodeProto(t *testing.T) {
 	}
 }
 
-func TestGetNodeMarshalTo(t *testing.T) {
+func TestExchangeNodeMarshalTo(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, false)
+	p := NewPopulatedExchangeNode(popr, false)
 	size := p.Size()
 	dAtA := make([]byte, size)
 	for i := range dAtA {
@@ -231,7 +231,7 @@ func TestGetNodeMarshalTo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNode{}
+	msg := &ExchangeNode{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -243,15 +243,15 @@ func TestGetNodeMarshalTo(t *testing.T) {
 	}
 }
 
-func TestGetNodeReplyProto(t *testing.T) {
+func TestExchangeNodeReplyProto(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, false)
+	p := NewPopulatedExchangeNodeReply(popr, false)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNodeReply{}
+	msg := &ExchangeNodeReply{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -274,10 +274,10 @@ func TestGetNodeReplyProto(t *testing.T) {
 	}
 }
 
-func TestGetNodeReplyMarshalTo(t *testing.T) {
+func TestExchangeNodeReplyMarshalTo(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, false)
+	p := NewPopulatedExchangeNodeReply(popr, false)
 	size := p.Size()
 	dAtA := make([]byte, size)
 	for i := range dAtA {
@@ -287,7 +287,7 @@ func TestGetNodeReplyMarshalTo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNodeReply{}
+	msg := &ExchangeNodeReply{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -689,16 +689,16 @@ func TestPingReplyJSON(t *testing.T) {
 		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
 	}
 }
-func TestGetNodeJSON(t *testing.T) {
+func TestExchangeNodeJSON(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, true)
+	p := NewPopulatedExchangeNode(popr, true)
 	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
 	jsondata, err := marshaler.MarshalToString(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNode{}
+	msg := &ExchangeNode{}
 	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
@@ -707,16 +707,16 @@ func TestGetNodeJSON(t *testing.T) {
 		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
 	}
 }
-func TestGetNodeReplyJSON(t *testing.T) {
+func TestExchangeNodeReplyJSON(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, true)
+	p := NewPopulatedExchangeNodeReply(popr, true)
 	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
 	jsondata, err := marshaler.MarshalToString(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &GetNodeReply{}
+	msg := &ExchangeNodeReply{}
 	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
@@ -917,12 +917,12 @@ func TestPingReplyProtoCompactText(t *testing.T) {
 	}
 }
 
-func TestGetNodeProtoText(t *testing.T) {
+func TestExchangeNodeProtoText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, true)
+	p := NewPopulatedExchangeNode(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
-	msg := &GetNode{}
+	msg := &ExchangeNode{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -931,12 +931,12 @@ func TestGetNodeProtoText(t *testing.T) {
 	}
 }
 
-func TestGetNodeProtoCompactText(t *testing.T) {
+func TestExchangeNodeProtoCompactText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, true)
+	p := NewPopulatedExchangeNode(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
-	msg := &GetNode{}
+	msg := &ExchangeNode{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -945,12 +945,12 @@ func TestGetNodeProtoCompactText(t *testing.T) {
 	}
 }
 
-func TestGetNodeReplyProtoText(t *testing.T) {
+func TestExchangeNodeReplyProtoText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, true)
+	p := NewPopulatedExchangeNodeReply(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
-	msg := &GetNodeReply{}
+	msg := &ExchangeNodeReply{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -959,12 +959,12 @@ func TestGetNodeReplyProtoText(t *testing.T) {
 	}
 }
 
-func TestGetNodeReplyProtoCompactText(t *testing.T) {
+func TestExchangeNodeReplyProtoCompactText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, true)
+	p := NewPopulatedExchangeNodeReply(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
-	msg := &GetNodeReply{}
+	msg := &ExchangeNodeReply{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -1180,9 +1180,9 @@ func TestPingReplyGoString(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-func TestGetNodeGoString(t *testing.T) {
+func TestExchangeNodeGoString(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedGetNode(popr, false)
+	p := NewPopulatedExchangeNode(popr, false)
 	s1 := p.GoString()
 	s2 := fmt.Sprintf("%#v", p)
 	if s1 != s2 {
@@ -1193,9 +1193,9 @@ func TestGetNodeGoString(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-func TestGetNodeReplyGoString(t *testing.T) {
+func TestExchangeNodeReplyGoString(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedGetNodeReply(popr, false)
+	p := NewPopulatedExchangeNodeReply(popr, false)
 	s1 := p.GoString()
 	s2 := fmt.Sprintf("%#v", p)
 	if s1 != s2 {
@@ -1350,10 +1350,10 @@ func TestPingReplySize(t *testing.T) {
 	}
 }
 
-func TestGetNodeSize(t *testing.T) {
+func TestExchangeNodeSize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNode(popr, true)
+	p := NewPopulatedExchangeNode(popr, true)
 	size2 := github_com_gogo_protobuf_proto.Size(p)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
@@ -1372,10 +1372,10 @@ func TestGetNodeSize(t *testing.T) {
 	}
 }
 
-func TestGetNodeReplySize(t *testing.T) {
+func TestExchangeNodeReplySize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedGetNodeReply(popr, true)
+	p := NewPopulatedExchangeNodeReply(popr, true)
 	size2 := github_com_gogo_protobuf_proto.Size(p)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
@@ -1553,18 +1553,18 @@ func TestPingReplyStringer(t *testing.T) {
 		t.Fatalf("String want %v got %v", s1, s2)
 	}
 }
-func TestGetNodeStringer(t *testing.T) {
+func TestExchangeNodeStringer(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedGetNode(popr, false)
+	p := NewPopulatedExchangeNode(popr, false)
 	s1 := p.String()
 	s2 := fmt.Sprintf("%v", p)
 	if s1 != s2 {
 		t.Fatalf("String want %v got %v", s1, s2)
 	}
 }
-func TestGetNodeReplyStringer(t *testing.T) {
+func TestExchangeNodeReplyStringer(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedGetNodeReply(popr, false)
+	p := NewPopulatedExchangeNodeReply(popr, false)
 	s1 := p.String()
 	s2 := fmt.Sprintf("%v", p)
 	if s1 != s2 {


### PR DESCRIPTION
Previously when B is ready on A's side, B may not have A's node info. Now when B is ready on A's side, B is guaranteed to have A's node information.

Signed-off-by: Yilun <zyl.skysniper@gmail.com>