### PR TITLE
Increase robustness to extremely slow nodes

### DIFF
--- a/node/remotenode.go
+++ b/node/remotenode.go
@@ -502,7 +502,7 @@ func (rn *RemoteNode) startMeasuringRoundTripTime() {
 	var roundTripTime time.Duration
 
 	for {
-		time.Sleep(util.RandDuration(rn.LocalNode.MeasureRoundTripTimeInterval, 1.0/3.0))
+		time.Sleep(util.RandDuration(rn.LocalNode.MeasureRoundTripTimeInterval, 1.0/5.0))
 
 		if rn.IsStopped() {
 			return
@@ -510,11 +510,12 @@ func (rn *RemoteNode) startMeasuringRoundTripTime() {
 
 		startTime = time.Now()
 		err = rn.Ping()
+		roundTripTime = time.Since(startTime)
 		if err != nil {
 			log.Warningf("Ping %v error: %v", rn, err)
-			continue
+			// This will guarantee rn.roundTripTime immediately becomes larger than any other available neighbors
+			roundTripTime = rn.LocalNode.DefaultReplyTimeout * 2
 		}
-		roundTripTime = time.Since(startTime)
 
 		rn.Lock()
 		if rn.roundTripTime > 0 {

--- a/overlay/chord/neighborlist.go
+++ b/overlay/chord/neighborlist.go
@@ -215,7 +215,7 @@ func (sl *NeighborList) ToRemoteNodeList(sorted bool) []*node.RemoteNode {
 	nodes := make([]*node.RemoteNode, 0)
 	sl.nodes.Range(func(key, value interface{}) bool {
 		rn, ok := value.(*node.RemoteNode)
-		if ok {
+		if ok && !rn.IsStopped() {
 			nodes = append(nodes, rn)
 		}
 		return true


### PR DESCRIPTION
* Increase measured RTT if ping msg timeout: This will avoid packets being routed to recently timeout neighbor
* Update lastRxTime only when receiving ping message: This may fix the case when remote node has extremely slow upstream bandwidth and all message timeout, but it still stays in other nodes' neighbors.
* ToRemoteNodeList only returns remote nodes that are not stopped