### PR TITLE
Prevent panic on close when net.Conn has nil underlying value but is not nil

### DIFF
--- a/node/localnode.go
+++ b/node/localnode.go
@@ -200,7 +200,7 @@ func (ln *LocalNode) listen() {
 		conn, err := listener.Accept()
 
 		if ln.IsStopped() {
-			if conn != nil {
+			if err != nil {
 				conn.Close()
 			}
 			return


### PR DESCRIPTION
Signed-off-by: Yilun <zyl.skysniper@gmail.com>