### PR TITLE
fixed the newrelaybytesmessage typo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nknorg/nnet
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.20
 
 require (
 	github.com/hashicorp/yamux v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nknorg/nnet
 
-go 1.20
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/hashicorp/yamux v0.1.2

--- a/message.go
+++ b/message.go
@@ -55,7 +55,7 @@ func (nn *NNet) NewRelayBytesMessage(data, srcID, key []byte) (*pbmsg.Message, e
 
 	msg := &pbmsg.Message{
 		MessageType: pbmsg.MessageType_BYTES,
-		RoutingType: pbmsg.RoutingType_DIRECT,
+		RoutingType: pbmsg.RoutingType_RELAY,
 		MessageId:   id,
 		Message:     buf,
 		SrcId:       srcID,


### PR DESCRIPTION
In the commit : 86ebba7
There was a typo that changed the message type for relay message to direct. This PR is in regards to the issue #51 . 


